### PR TITLE
Add Decoder::into_inner method to enable unsafe code removal in ureq.

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -46,6 +46,8 @@ pub struct Decoder<R> {
 }
 
 impl<R> Decoder<R>
+where
+    R: Read,
 {
     pub fn new(source: R) -> Decoder<R> {
         Decoder {
@@ -58,12 +60,7 @@ impl<R> Decoder<R>
     pub fn into_inner(self) -> R {
         self.source
     }
-}
 
-impl<R> Decoder<R>
-where
-    R: Read,
-{
     fn read_chunk_size(&mut self) -> IoResult<usize> {
         let mut chunk_size_bytes = Vec::new();
         let mut has_ext = false;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -46,8 +46,6 @@ pub struct Decoder<R> {
 }
 
 impl<R> Decoder<R>
-where
-    R: Read,
 {
     pub fn new(source: R) -> Decoder<R> {
         Decoder {
@@ -56,6 +54,16 @@ where
         }
     }
 
+    /// Unwraps the inner read source.
+    pub fn unwrap(self) -> R {
+        self.source
+    }
+}
+
+impl<R> Decoder<R>
+where
+    R: Read,
+{
     fn read_chunk_size(&mut self) -> IoResult<usize> {
         let mut chunk_size_bytes = Vec::new();
         let mut has_ext = false;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -54,8 +54,8 @@ impl<R> Decoder<R>
         }
     }
 
-    /// Unwraps the inner read source.
-    pub fn unwrap(self) -> R {
+    /// Unwraps the Decoder into its inner `Read` source.
+    pub fn into_inner(self) -> R {
         self.source
     }
 }


### PR DESCRIPTION
ureq's last remaining unsafe code blocks are present because it wants to return a `Read` enum (representing an HTTP stream) back to a pool after wrapping the enum in a `Decoder` from this crate. The problem is there is no way of "unwrapping" a `Read` after it has been passed to `Decoder::new`. This tiny PR fixes that by adding an `unwrap` method, which will allow ureq's unsafe code to be removed.