### PR TITLE
Performance: One write syscall per chunk.

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -109,11 +109,11 @@ where
         // Prepend the length and \r\n to the buffer.
         let prelude = format!("{:x}\r\n", self.buffer.len() - HEADER_SIZE);
         let prelude = prelude.as_bytes();
-        if prelude.len() > HEADER_SIZE {
-            // This should never happen because MAX_CHUNK_SIZE of u32::MAX
-            // can always be encoded in 4 hex bytes.
-            panic!("invariant failed: prelude longer than HEADER_SIZE");
-        }
+
+        // This should never happen because MAX_CHUNK_SIZE of u32::MAX
+        // can always be encoded in 4 hex bytes.
+        assert!(HEADER_SIZE <= prelude.len(), "invariant failed: prelude longer than HEADER_SIZE");
+
         // Copy the prelude into the buffer. For small chunks, this won't necessarily
         // take up all the space that was reserved for the prelude.
         let offset = HEADER_SIZE - prelude.len();

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -116,7 +116,7 @@ where
 
         // This should never happen because MAX_CHUNK_SIZE of u32::MAX
         // can always be encoded in 4 hex bytes.
-        assert!(PLACEHOLDER_HEADER_SIZE <= prelude.len(), "invariant failed: prelude longer than PLACEHOLDER_HEADER_SIZE");
+        assert!(prelude.len() <= PLACEHOLDER_HEADER_SIZE, "invariant failed: prelude longer than PLACEHOLDER_HEADER_SIZE");
 
         // Copy the prelude into the buffer. For small chunks, this won't necessarily
         // take up all the space that was reserved for the prelude.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -66,11 +66,7 @@ where
     }
 
     pub fn with_chunks_size(output: W, chunks: usize) -> Encoder<W> {
-        let chunks_size = if chunks > MAX_CHUNK_SIZE {
-            MAX_CHUNK_SIZE
-        } else {
-            chunks
-        };
+        let chunks_size = chunks.min(MAX_CHUNK_SIZE);
         let mut encoder = Encoder {
             output,
             chunks_size,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -91,9 +91,9 @@ where
     fn reset_buffer(&mut self) {
         // Reset buffer
         self.buffer.clear();
-        // Arbitrary bytes to take up space. Should never be seen in output.
-        let placeholder: [u8; PLACEHOLDER_HEADER_SIZE] = *b"DACE\r\n";
-        self.buffer.extend_from_slice(&placeholder);
+        // Reserve space for the chunk size. This space will be populated once
+        // we know the size of the chunk.
+        self.buffer.resize(PLACEHOLDER_HEADER_SIZE, 0);
     }
 
     fn is_buffer_empty(&self) -> bool {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -138,7 +138,6 @@ where
     W: Write,
 {
     fn write(&mut self, data: &[u8]) -> IoResult<usize> {
-        println!("writing to buffer: {:?}", data);
         let buffer_size = self.buffer.len() - HEADER_SIZE;
         let remaining_buffer_space = self.chunks_size - buffer_size;
         let bytes_to_buffer = std::cmp::min(remaining_buffer_space, data.len());

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -96,14 +96,14 @@ where
         self.buffer.extend_from_slice(&placeholder);
     }
 
-    fn buffer_empty(&self) -> bool {
+    fn is_buffer_empty(&self) -> bool {
         self.buffer.len() == HEADER_SIZE
     }
 
     fn send(&mut self) -> IoResult<()> {
         // Never send an empty buffer, because that would be interpreted
         // as the end of the stream, which we indicate explicitly on drop.
-        if self.buffer_empty() {
+        if self.is_buffer_empty() {
             return Ok(());
         }
         // Prepend the length and \r\n to the buffer.
@@ -180,7 +180,7 @@ mod test {
         {
             let mut encoder = Encoder::with_chunks_size(dest.by_ref(), 5);
             io::copy(&mut source, &mut encoder).unwrap();
-            assert!(!encoder.buffer_empty());
+            assert!(!encoder.is_buffer_empty());
         }
 
         let output = from_utf8(&dest).unwrap();
@@ -196,7 +196,7 @@ mod test {
             let mut encoder = Encoder::with_flush_after_write(dest.by_ref());
             io::copy(&mut source, &mut encoder).unwrap();
             // The internal buffer has been flushed.
-            assert!(encoder.buffer_empty());
+            assert!(encoder.is_buffer_empty());
         }
 
         let output = from_utf8(&dest).unwrap();


### PR DESCRIPTION
This ports over an optimization from
https://github.com/algesten/ureq/pull/44, to do just one write syscall
per chunk. It does so efficiently by always reserving space for the
chunk size at the beginning of the buffer, so we don't have to copy lots
of memory around when it comes time to write the chunk.