### PR TITLE
Expose Decoder::remaining_chunks_size

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -56,6 +56,11 @@ where
         }
     }
 
+	/// Returns the remaining bytes left in the chunk being read.
+	pub fn remaining_chunks_size(&self) -> Option<usize> {
+		self.remaining_chunks_size
+	}
+
     /// Unwraps the Decoder into its inner `Read` source.
     pub fn into_inner(self) -> R {
         self.source

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -56,10 +56,10 @@ where
         }
     }
 
-	/// Returns the remaining bytes left in the chunk being read.
-	pub fn remaining_chunks_size(&self) -> Option<usize> {
-		self.remaining_chunks_size
-	}
+    /// Returns the remaining bytes left in the chunk being read.
+    pub fn remaining_chunks_size(&self) -> Option<usize> {
+        self.remaining_chunks_size
+    }
 
     /// Unwraps the Decoder into its inner `Read` source.
     pub fn into_inner(self) -> R {


### PR DESCRIPTION
This is a workaround for using Decoder with tokio::io::AsyncRead. The
line containing the chunk size can be read asynchronously and decoded by
Decoder. Then the chunk itself can be read asynchronously now that its
size is known.

Workaround for the read half of #7.