### PR TITLE
Handle missing \r\n at end of message

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -124,6 +124,39 @@ where
             _ => Err(IoError::new(ErrorKind::InvalidInput, DecoderError)),
         }
     }
+
+    // Sometimes the last \r\n is missing.
+    fn read_end(&mut self) -> IoResult<()> {
+        fn expect_or_end(
+            bytes: &mut impl Iterator<Item = IoResult<u8>>,
+            expected: u8,
+        ) -> IoResult<()> {
+            match bytes.next() {
+                Some(Ok(c)) => {
+                    if c == expected {
+                        Ok(())
+                    } else {
+                        Err(IoError::new(ErrorKind::InvalidInput, DecoderError))
+                    }
+                }
+                Some(Err(e)) => {
+                    match e.kind() {
+                        // Closed connections are ok.
+                        ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted => Ok(()),
+                        _ => Err(IoError::new(ErrorKind::InvalidInput, DecoderError)),
+                    }
+                }
+                None => Ok(()), // End of iterator is ok
+            }
+        }
+
+        let mut bytes = self.source.by_ref().bytes();
+
+        expect_or_end(&mut bytes, b'\r')?;
+        expect_or_end(&mut bytes, b'\n')?;
+
+        Ok(())
+    }
 }
 
 impl<R> Read for Decoder<R>
@@ -140,8 +173,7 @@ where
 
                 // if the chunk size is 0, we are at EOF
                 if chunk_size == 0 {
-                    self.read_carriage_return()?;
-                    self.read_line_feed()?;
+                    self.read_end()?;
                     return Ok(0);
                 }
 
@@ -301,5 +333,24 @@ mod test {
 
         let mut string = String::new();
         assert!(decoded.read_to_string(&mut string).is_err());
+    }
+
+    #[test]
+    fn test_decode_end_missing_last_crlf() {
+        // This has been observed in the wild.
+        // See https://github.com/algesten/ureq/issues/325
+
+        // Missing last \r\n
+        let source = io::Cursor::new(
+            "3\r\nhel\r\nb\r\nlo world!!!\r\n0\r\n"
+                .to_string()
+                .into_bytes(),
+        );
+        let mut decoded = Decoder::new(source);
+
+        let mut string = String::new();
+        assert!(decoded.read_to_string(&mut string).is_ok());
+
+        assert_eq!(string, "hello world!!!");
     }
 }


### PR DESCRIPTION
Hello and thanks for the `chunked_transfer` crate!

In ureq we have found a small number of sites in the wild that omits sending the last `\r\n`. See https://github.com/algesten/ureq/issues/325

I.e. instead of going

```
0\r\n
\r\n
```

They just send

```
0\r\n
```

and then close the connection.

This is a case that curl's chunked decoder handles. You can see such a misbehaving site with:

```
curl --http1.1 -L --trace ./trace.txt https://www.sunnysports.com/ && cat trace.txt
```

I don't know whether you're interested in supporting broken sites like this – in some respects it's a case of "fix your broken web server" – however since curl handles it, I thought it was worth to at least discuss it.
