### PR TITLE
Add get_ref and get_mut methods to Decoder and Encoder

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -51,6 +51,16 @@ where
         self.source
     }
 
+    /// Gets a reference to the underlying value in this decoder.
+    pub fn get_ref(&self) -> &R {
+        &self.source
+    }
+
+    /// Gets a mutable reference to the underlying value in this decoder.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.source
+    }
+
     fn read_chunk_size(&mut self) -> IoResult<usize> {
         let mut chunk_size_bytes = Vec::new();
         let mut has_ext = false;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -52,6 +52,16 @@ where
         Encoder::with_chunks_size(output, 8192)
     }
 
+    /// Gets a reference to the underlying value in this encoder.
+    pub fn get_ref(&self) -> &W {
+        &self.output
+    }
+
+    /// Gets a mutable reference to the underlying value in this encoder.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.output
+    }
+
     pub fn with_chunks_size(output: W, chunks: usize) -> Encoder<W> {
         let chunks_size = chunks.min(MAX_CHUNK_SIZE);
         let mut encoder = Encoder {


### PR DESCRIPTION
This pull request adds two methods to the Decoder and Encoder:
- get_ref
- get_mut

These methods allow accessing the inner reader/writer as a (mutable) reference.
The description is made to mimic the one present for similar std functions.

I think it would be really useful to have them as a feature here as well, for example if you
are wrapping something like a TCP stream directly inside a Decoder and need to access some specific functionality from the inner stream.